### PR TITLE
fix: correct typo applcation -> application in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 	defer db.Close()
 
 	// set reasonable connection pooling limits. These limits
-	// are rather low because the applcation currently really
+	// are rather low because the application currently really
 	// only needs a single open connection.
 	db.SetMaxOpenConns(5)
 	db.SetMaxIdleConns(3)


### PR DESCRIPTION
## Description

Fix a typo in a source comment at `main.go:106`: `"applcation"` should be `"application"`.

## Changes

- `main.go:106`: 1 line changed

Fixes issue #28.